### PR TITLE
Add support for using Roblox services

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ import.setConfig({
 local module = import("shared/Module")
 ```
 
+You can also configure the module to use WaitForChild, with a configurable timeout
+
+```lua
+import.setConfig({
+	useWaitForChild = true
+	waitForChildTimeout = 1
+})
+```
+
 Works for any Roblox instance, so you can use this to import assets as well:
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ local foo = import("./Module", { "foo" })
 local foo, bar = import("./Module", { "foo", "bar" })
 ```
 
+Roblox services can be imported by starting the path with them:
+
+```lua
+-- local module = require(game.ReplicatedStorage.module)
+local module = import("ReplicatedStorage/module")
+
+-- local module = require(game.ServerStorage.module)
+local module = import("ServerStorage/module")
+```
+
 You can set aliases to define starting points for your paths:
 
 ```lua

--- a/src/Importer.spec.lua
+++ b/src/Importer.spec.lua
@@ -114,7 +114,7 @@ return function()
 			expect(module.foo).to.equal("foo")
 		end)
 
-		it("should import a module down one level down (script.Parent:FindFirstChild())", function()
+		it("should import a module one level down (script.Parent:FindFirstChild())", function()
 			local mockScript = Instance.new("Script")
 			local mockModule = MOCK_TABLE_MODULE:Clone()
 
@@ -159,6 +159,8 @@ return function()
 		-- 	expect(module.foo).to.equal("foo")
 		-- end)
 
+
+
 		it("should have support for aliases", function()
 			local mockScript = Instance.new("Script")
 			local mockModule = MOCK_TABLE_MODULE:Clone()
@@ -185,6 +187,41 @@ return function()
 
 			expect(type(module)).to.equal("table")
 			expect(module.foo).to.equal("foo")
+		end)
+
+
+		describe("roblox services", function()
+			it("should have support for Roblox services", function()
+				local mockScript = Instance.new("Script")
+				local importer = Importer.new()
+
+				expect(importer:import(mockScript, "ReplicatedStorage")).to.equal(game.ReplicatedStorage)
+				expect(importer:import(mockScript, "ServerScriptService")).to.equal(game.ServerScriptService)
+				expect(importer:import(mockScript, "ServerStorage")).to.equal(game.ServerStorage)
+			end)
+
+			it("should import instances inside services", function()
+				-- Since we can't mock a service, we just have to be careful and
+				-- clear up afterwards.
+
+				local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+				local mockScript = Instance.new("Script")
+				local mockModule = MOCK_TABLE_MODULE:Clone()
+				mockModule.Name = "Module"
+				mockModule.Parent = ReplicatedStorage
+
+				local importer = Importer.new()
+
+				local module = importer:import(mockScript, "ReplicatedStorage/Module")
+
+				expect(type(module)).to.equal("table")
+				expect(module.foo).to.equal("foo")
+
+				-- Clean up, otherwise we'll be fill up ReplicatedStorage with
+				-- garbage over time.
+				mockModule:Destroy()
+			end)
 		end)
 
 		describe("importing individual exports", function()

--- a/src/Importer.spec.lua
+++ b/src/Importer.spec.lua
@@ -36,7 +36,9 @@ return function()
 			local oldConfig = importer._config
 
 			importer:setConfig({
-				aliases = { foo = Instance.new("Part") }
+				aliases = { foo = Instance.new("Part") },
+				useWaitForChild = true,
+				waitForChildTimeout = 1,
 			})
 
 			expect(importer._config).to.never.equal(oldConfig)
@@ -54,6 +56,29 @@ return function()
 	end)
 
 	describe("import", function()
+		it("shouldn't break if using waitForChild", function()
+			local mockScript = Instance.new("Script")
+			local mockModule = MOCK_TABLE_MODULE:Clone()
+
+			local mockDataModel = newFolder({
+				Module = mockModule,
+				Script = mockScript,
+			})
+
+			local importer = Importer.new(mockDataModel)
+
+			importer:setConfig({
+				useWaitForChild = true,
+				waitForChildTimeout = 1
+			})
+
+			-- local module = require(script.Parent.Module)
+			local module = importer:import(mockScript, "./Module")
+
+			expect(type(module)).to.equal("table")
+			expect(module.foo).to.equal("foo")
+		end)
+
 		it("should import a module from the same level (script.Parent)", function()
 			local mockScript = Instance.new("Script")
 			local mockModule = MOCK_TABLE_MODULE:Clone()


### PR DESCRIPTION
This adds support for the first part of the path optionally matching any Roblox service.

For example:

```lua
local foo = import("ReplicatedStorage/Path/To/Foo")
```

Unsure if this is worth merging though. My use case for this was using it as an escape hatch when I couldn't otherwise access something under ReplicatedStorage. Aliases are able to fix this so it might be best just to make aliases the recommended approach.

Or, if this is a wanted feature, we should instead use a syntax where "/" resolves to the datamodel, so we could do `import("/ReplicatedStorage/Foo")`, and avoid the hacky service finding method in use in this PR.