### PR TITLE
Automatically attach builds to the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,3 @@ jobs:
           files: import.rbxmx
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  add-to-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: Roblox/setup-foreman@v1
+        with:
+          version: "^1.0.0"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        run: rojo build -o import.rbxmx
+
+      - name: Add model file to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: import.rbxmx
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
# Problem

When creating a new release in GitHub, we have to manually attach builds of the model file

# Solution

Use a GitHub action to build and attach the model when a new release is published

# Checklist

~- [ ] Test case(s) written~
~- [ ] Any public APIs are documented in the README~
