### PR TITLE
Use Luau types where applicable

### DIFF
--- a/src/Options.lua
+++ b/src/Options.lua
@@ -2,7 +2,7 @@ local join = require(script.Parent.join)
 
 local Options = {}
 
-function Options.new(defaults, validator)
+function Options.new(defaults: { [string]: any }, validator: (any) -> boolean)
 	local self = {}
 
 	self.values = defaults

--- a/src/createImporter.lua
+++ b/src/createImporter.lua
@@ -2,6 +2,12 @@ local t = require(script.Parent.t)
 local createPathTraverser = require(script.Parent.createPathTraverser)
 local destructure = require(script.Parent.destructure)
 
+type Options = {
+	useWaitForChild: boolean?,
+	waitForChildTimeout: number?,
+	scriptAlias: string?,
+	aliases: ({ [string]: Instance })?,
+}
 local Options = t.strictInterface({
 	useWaitForChild = t.optional(t.boolean),
 	waitForChildTimeout = t.optional(t.number),
@@ -12,12 +18,12 @@ local Options = t.strictInterface({
 local checkOuter = t.tuple(t.Instance, t.Instance, t.optional(Options))
 local checkInner = t.tuple(t.string, t.optional(t.array(t.string)))
 
-local function createImporter(root, start, options)
+local function createImporter(root: Instance, start: Instance, options: Options)
 	assert(checkOuter(root, start, options))
 
 	options = options or {}
 
-	return function(path, exports)
+	return function(path: string, exports: ({ string })?)
 		assert(checkInner(path, exports))
 
 		-- This condition is true when the user calls `import("script")`. In

--- a/src/destructure.lua
+++ b/src/destructure.lua
@@ -14,7 +14,7 @@
 
 local NOT_FOUND_ERROR = "Failed to destructure while importing (no export named %q found)"
 
-local function destructure(object, members)
+local function destructure(object: { [string]: any }, members: { string })
 	local result = {}
 
 	for _, memberName in ipairs(members) do

--- a/src/init.lua
+++ b/src/init.lua
@@ -22,7 +22,7 @@ local aliases = Options.new({}, t.map(t.string, t.Instance))
 
 local check = t.tuple(t.string, t.optional(t.array(t.string)))
 
-local function importWithCallingScript(caller, path, exports)
+local function importWithCallingScript(caller: BaseScript, path: string, exports: ({ string })?)
 	assert(check(path, exports))
 
 	local import = createImporter(config.values.root, caller, {
@@ -40,14 +40,14 @@ end
 local api = setmetatable({
 	setConfig = config.set,
 	setAliases = aliases.set,
-	import = function(path, exports)
+	import = function(path: string, exports: ({ string })?)
 		local caller = getfenv(2).script
 		return importWithCallingScript(caller, path, exports)
 	end,
 }, {
 	-- Allows this module to be called as import(), otherwise the user has to write
 	-- import.import()
-	__call = function(_, path, exports)
+	__call = function(_, path: string, exports: ({ string })?)
 		local caller = getfenv(2).script
 		return importWithCallingScript(caller, path, exports)
 	end,

--- a/src/newFolder.lua
+++ b/src/newFolder.lua
@@ -2,7 +2,7 @@
 	Helper function used in tests. This makes it easy to construct hierarchies
 	to test out importing in various settings.
 ]]
-local function newFolder(children)
+local function newFolder(children: { [string]: Instance }): Folder
 	local folder = Instance.new("Folder")
 	folder.Name = "root"
 


### PR DESCRIPTION
# Problem

Only some parts of the codebase are typed. We should be striving to have 100% covered by Luau types

# Solution

Add types to most functions

- [ ] Test case(s) written
- [ ] Any public APIs are documented in the README
