### PR TITLE
Remove documentation for detectRequireLoops

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ Name | Description | Default
 `useWaitForChild` | By default, FindFirstChild is used when traversing the hierarchy. Set to `true` to use WaitForChild instead | false
 `waitForChildTimeout` | When `useWaitForChild` is set to `true`, this controls how long (in seconds) to yield before resolving | 1
 `scriptAlias` | Controls the name of the alias that is reserved for the current script | `"script"`
-`detectRequireLoops` | By default, `import` will throw an error when ModuleScripts attempt to require eachother in a recursive loop (which would otherwise silently fail). This feature was designed with the assumption the user only has a singular Script or LocalScript as the entry point to the codebase, and this feature can be disabled if it causes problems | true
 
 ```lua
 local import = require(game.ReplicatedStorage.import)


### PR DESCRIPTION
# Problem

Documentation for detectRequireLoops still exists, despite it not being implemented in this version of the package.

# Solution

Remove the final remnants of require loop detection. This is done automatically by Roblox now, so we don't have to implement it ourselves again

- [ ] Test case(s) written
- [ ] Any public APIs are documented in the README
